### PR TITLE
v1.0.1 - Unification Patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build Status (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Functional Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-07-14
+
+### Changed
+
+- Unified configuration variable names:
+  - `FAKE_USERAGENT_RANDOM_UA_TYPE` → `FAKE_USERAGENT_UA_TYPE`
+  - `FAKER_RANDOM_UA_TYPE` → `FAKER_UA_TYPE`
+- Introduced `USERAGENT_PROVIDERS` as the new primary setting key for provider order.
+  - `FAKEUSERAGENT_PROVIDERS` is now **deprecated** but still supported for backward compatibility with a warning.
+
+### Fixed
+
+- Updated internal logic to support both `USERAGENT_PROVIDERS` and legacy `FAKEUSERAGENT_PROVIDERS` with clear warnings.
+- All relevant tests and documentation were updated to reflect the new configuration format.
+
 ## [1.0.0] - 2025-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+
 # scrapy-ua-rotator
 
 [![PyPI](https://img.shields.io/pypi/v/scrapy-ua-rotator)](https://pypi.org/project/scrapy-ua-rotator/)
@@ -52,7 +53,7 @@ DOWNLOADER_MIDDLEWARES = {
 Recommended provider order:
 
 ```python
-FAKEUSERAGENT_PROVIDERS = [
+USERAGENT_PROVIDERS = [
     'scrapy_ua_rotator.providers.FakeUserAgentProvider',  # Primary provider using the fake-useragent library
     'scrapy_ua_rotator.providers.FakerProvider',          # Fallback provider that generates synthetic UAs via Faker
     'scrapy_ua_rotator.providers.FixedUserAgentProvider', # Final fallback: uses the static USER_AGENT setting
@@ -72,10 +73,10 @@ Assigns a new user-agent using [`fake-useragent`](https://github.com/fake-userag
 Supports fine-tuned filtering via:
 
 ```python
-FAKE_USERAGENT_RANDOM_UA_TYPE = 'Chrome Mobile iOS'   # str; browser to prioritize (default: 'random')
-FAKEUSERAGENT_OS = ['Linux']                          # str or list[str]; OS filter (default: None — all OSes)
-FAKEUSERAGENT_PLATFORMS = ['mobile']                  # str or list[str]; platform filter (default: None — all platforms)
-FAKEUSERAGENT_FALLBACK = 'Mozilla/5.0 (...)'          # str; fallback UA string (default: internal fallback)
+FAKE_USERAGENT_UA_TYPE = 'Chrome Mobile iOS'           # str; browser to prioritize (default: 'random')
+FAKE_USERAGENT_OS = ['Linux']                          # str or list[str]; OS filter (default: None — all OSes)
+FAKE_USERAGENT_PLATFORMS = ['mobile']                  # str or list[str]; platform filter (default: None — all platforms)
+FAKE_USERAGENT_FALLBACK = 'Mozilla/5.0 (...)'          # str; fallback UA string (default: internal fallback)
 ```
 
 > 💡 **Note:** See [docs](https://github.com/fake-useragent/fake-useragent/blob/main/README.md) for supported options and advanced usage.
@@ -85,10 +86,10 @@ FAKEUSERAGENT_FALLBACK = 'Mozilla/5.0 (...)'          # str; fallback UA string 
 Uses [`Faker`](https://faker.readthedocs.io/en/stable/providers/faker.providers.user_agent.html) to generate synthetic UA strings.
 
 ```python
-FAKER_RANDOM_UA_TYPE = 'chrome'  # or 'firefox', 'safari', etc.
+FAKER_UA_TYPE = 'chrome'  # or 'firefox', 'safari', etc. (default: 'user_agent' — random web browser)
 ```
 
-> 💡 **Note:** See [docs](https://github.com/joke2k/faker/blob/master/README.rst) for supported options and advanced usage.
+> 💡 **Note:** See [docs](https://faker.readthedocs.io/en/stable/providers/faker.providers.user_agent.html) for supported options and advanced usage.
 
 ### FixedUserAgentProvider
 
@@ -129,7 +130,7 @@ def parse(self, response):
 Add your own class:
 
 ```python
-FAKEUSERAGENT_PROVIDERS = [
+USERAGENT_PROVIDERS = [
     'your_project.providers.MyCustomProvider',
     ...
 ]

--- a/scrapy_ua_rotator/middleware.py
+++ b/scrapy_ua_rotator/middleware.py
@@ -26,10 +26,19 @@ class RandomUserAgentBase:
 
     def _get_provider(self, crawler: Crawler) -> Any:
         """Load the first available provider from settings or fall back to FixedUserAgentProvider."""
-        self.providers_paths = crawler.settings.get(
-            'FAKEUSERAGENT_PROVIDERS', None)
-        if not self.providers_paths:
+
+        self.providers_paths = (
+            crawler.settings.get('USERAGENT_PROVIDERS')
+            or crawler.settings.get('FAKEUSERAGENT_PROVIDERS')
+        )
+
+        if self.providers_paths is None:
             self.providers_paths = [FAKE_USERAGENT_PROVIDER_PATH]
+        elif 'FAKEUSERAGENT_PROVIDERS' in crawler.settings.attributes:
+            logger.warning(
+                "Setting 'FAKEUSERAGENT_PROVIDERS' is deprecated. "
+                "Use 'USERAGENT_PROVIDERS' instead."
+            )
 
         for provider_path in self.providers_paths:
             try:

--- a/scrapy_ua_rotator/providers.py
+++ b/scrapy_ua_rotator/providers.py
@@ -51,12 +51,12 @@ class FakeUserAgentProvider(BaseProvider):
     def __init__(self, settings: Settings):
         super().__init__(settings)
         self._ua_type: str = settings.get(
-            'FAKE_USERAGENT_RANDOM_UA_TYPE', self.DEFAULT_UA_TYPE)
+            'FAKE_USERAGENT_UA_TYPE', self.DEFAULT_UA_TYPE)
         self._ua_os: Optional[Union[str, List[str]]] = settings.get(
             'FAKE_USERAGENT_OS', self.DEFAULT_OS)
         self._ua_platforms: Optional[Union[str, List[str]]] = settings.get(
-            'FAKEUSERAGENT_PLATFORMS', self.DEFAULT_PLATFORMS)
-        fallback: str = settings.get('FAKEUSERAGENT_FALLBACK', '')
+            'FAKE_USERAGENT_PLATFORMS', self.DEFAULT_PLATFORMS)
+        fallback: str = settings.get('FAKE_USERAGENT_FALLBACK', '')
 
         if fake_useragent:
             try:
@@ -101,7 +101,7 @@ class FakerProvider(BaseProvider):
         super().__init__(settings)
         self._ua = Faker()
         self._ua_type: str = settings.get(
-            'FAKER_RANDOM_UA_TYPE', self.DEFAULT_UA_TYPE)
+            'FAKER_UA_TYPE', self.DEFAULT_UA_TYPE)
 
     def get_random_ua(self) -> str:
         try:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(path, "README.md"), "r", encoding="utf-8") as f:
 
 setup(
     name='scrapy-ua-rotator',
-    version='1.0.0',
+    version='1.0.1',
     author='Sergei Denisenko',
     author_email='sergei.denisenko@ieee.org',
     description='Flexible and modern User-Agent rotator middleware for Scrapy, supporting Faker, fake-useragent, and custom providers.',

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -114,7 +114,7 @@ def test_assigns_ua_per_proxy(monkeypatch, dummy_request):
 def test_provider_fallback_on_invalid_path(monkeypatch):
     class DummyCrawler:
         settings = Settings(
-            {'FAKEUSERAGENT_PROVIDERS': ['invalid.module.Provider']})
+            {'USERAGENT_PROVIDERS': ['invalid.module.Provider']})
         stats = Mock()
 
     mw = RandomUserAgentMiddleware.from_crawler(DummyCrawler())
@@ -157,7 +157,7 @@ def test_exception_not_retry(monkey_provider):
 
 def test_multiple_provider_failures(monkeypatch):
     class DummyCrawler:
-        settings = Settings({'FAKEUSERAGENT_PROVIDERS': [
+        settings = Settings({'USERAGENT_PROVIDERS': [
                             'invalid.path1', 'invalid.path2']})
         stats = Mock()
 
@@ -174,7 +174,7 @@ def test_valid_provider_load(monkeypatch):
         "scrapy_ua_rotator.middleware.load_object", lambda path: DummyProvider)
 
     class DummyCrawler:
-        settings = Settings({'FAKEUSERAGENT_PROVIDERS': [
+        settings = Settings({'USERAGENT_PROVIDERS': [
                             'scrapy_ua_rotator.providers.FixedUserAgentProvider']})
         stats = Mock()
 
@@ -251,3 +251,15 @@ def test_sets_user_agent_with_no_proxy_and_no_header(monkey_provider):
 
     mw.process_request(request, DummySpider("dummy"))
     assert request.headers.get("User-Agent").decode() == "Dummy-UA"
+
+
+def test_deprecated_provider_setting_warning(monkeypatch, caplog):
+    class DummyCrawler:
+        settings = Settings({'FAKEUSERAGENT_PROVIDERS': [
+                            'scrapy_ua_rotator.providers.FixedUserAgentProvider']})
+        stats = Mock()
+
+    caplog.set_level("WARNING")
+    RandomUserAgentMiddleware.from_crawler(DummyCrawler())
+
+    assert any("deprecated" in msg for msg in caplog.messages)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -24,14 +24,14 @@ def test_faker_provider_default():
 
 
 def test_faker_provider_with_type():
-    settings = Settings({"FAKER_RANDOM_UA_TYPE": "chrome"})
+    settings = Settings({"FAKER_UA_TYPE": "chrome"})
     provider = FakerProvider(settings)
     ua = provider.get_random_ua()
     assert "Chrome" in ua or "Mozilla" in ua
 
 
 def test_faker_provider_invalid_type():
-    settings = Settings({"FAKER_RANDOM_UA_TYPE": "nonexistent"})
+    settings = Settings({"FAKER_UA_TYPE": "nonexistent"})
     provider = FakerProvider(settings)
     ua = provider.get_random_ua()
     assert isinstance(ua, str)
@@ -44,9 +44,9 @@ def test_fake_useragent_provider(monkeypatch):
         pytest.skip("fake-useragent is not installed")
 
     settings = Settings({
-        "FAKE_USERAGENT_RANDOM_UA_TYPE": "chrome",
-        "FAKEUSERAGENT_OS": ["Linux"],
-        "FAKEUSERAGENT_PLATFORMS": ["desktop"]
+        "FAKE_USERAGENT_UA_TYPE": "chrome",
+        "FAKE_USERAGENT_OS": ["Linux"],
+        "FAKE_USERAGENT_PLATFORMS": ["desktop"]
     })
 
     provider = FakeUserAgentProvider(settings)
@@ -62,7 +62,7 @@ def test_fake_useragent_dict_and_attr(monkeypatch):
         pytest.skip("fake-useragent is not installed")
 
     settings = Settings({
-        "FAKE_USERAGENT_RANDOM_UA_TYPE": "Chrome Mobile iOS",
+        "FAKE_USERAGENT_UA_TYPE": "Chrome Mobile iOS",
     })
     provider = FakeUserAgentProvider(settings)
     assert isinstance(provider.get_random_ua(), str)
@@ -76,7 +76,7 @@ def test_fake_useragent_provider_invalid_type(monkeypatch):
     monkeypatch.setattr("scrapy_ua_rotator.providers.fake_useragent", type("mod", (), {
         "UserAgent": lambda **kwargs: DummyUA()
     }))
-    settings = Settings({"FAKE_USERAGENT_RANDOM_UA_TYPE": "nonexistent"})
+    settings = Settings({"FAKE_USERAGENT_UA_TYPE": "nonexistent"})
     provider = FakeUserAgentProvider(settings)
     assert provider.get_random_ua() is None
 


### PR DESCRIPTION
## [1.0.1] - 2025-07-14

### Changed

- Unified configuration variable names:
  - `FAKE_USERAGENT_RANDOM_UA_TYPE` → `FAKE_USERAGENT_UA_TYPE`
  - `FAKER_RANDOM_UA_TYPE` → `FAKER_UA_TYPE`
- Introduced `USERAGENT_PROVIDERS` as the new primary setting key for provider order.
  - `FAKEUSERAGENT_PROVIDERS` is now **deprecated** but still supported for backward compatibility with a warning.

### Fixed

- Updated internal logic to support both `USERAGENT_PROVIDERS` and legacy `FAKEUSERAGENT_PROVIDERS` with clear warnings.
- All relevant tests and documentation were updated to reflect the new configuration format.
